### PR TITLE
Don't Care Types: add () as a zero-sized StaticallySized type

### DIFF
--- a/src/types/scalar.rs
+++ b/src/types/scalar.rs
@@ -34,6 +34,11 @@ impl<A: StaticallySized, B: StaticallySized> StaticallySized for (A, B) {
     const SIZE: usize = A::SIZE + B::SIZE;
 }
 
+impl StaticallySized for () {
+    const SIZE: usize = 0;
+    // This type is used to make it explicit that we don't care about the value.
+}
+
 #[cfg(test)]
 mod tests {
     use crate::types::{DAMType, StaticallySized};


### PR DESCRIPTION
Add () as a zero-sized StaticallySized type.
This type is used to make it explicit that we don't care about the value.
One example of this case would be when you care about the position of elements in the stream rather than the value itself.