### PR TITLE
added bf16 to DAMType

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0.103"
 enum_dispatch = "0.3.12"
 petgraph = "0.6.3"
 rustc-hash = "1.1.0"
+half = "2.4.0"
 
 # For running different thread priorities and enabling FIFO Execution
 thread-priority = "0.13.1"

--- a/src/types/scalar.rs
+++ b/src/types/scalar.rs
@@ -2,6 +2,7 @@
 //! This registers the common datatypes as statically sized DAMTypes, such as u64, f32, etc.
 
 use super::StaticallySized;
+use half::bf16;
 
 macro_rules! builtin_ss {
     ($tp: tt, $nbits: literal) => {
@@ -23,6 +24,7 @@ builtin_ss!(u64, 64);
 
 builtin_ss!(f32, 32);
 builtin_ss!(f64, 64);
+builtin_ss!(bf16, 16);
 
 impl StaticallySized for usize {
     const SIZE: usize = unimplemented!();


### PR DESCRIPTION
1. Add the half crate to Cargo.toml
2. update src/types/scalar.rs to add bf16 to the supported data type